### PR TITLE
Add NullTraceProvider.

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -7,6 +7,8 @@ is updated in preparation for publishing an updated NuGet package.
 
 Prefix the description of the change with `[major]`, `[minor]` or `[patch]` in accordance with [SemVer](http://semver.org).
 
+* [patch] Add `NullTraceProvider`.
+
 ## Released
 
 ### 0.1.0

--- a/src/Faithlife.Tracing.AspNetMvc/AspNetMvcTracing.cs
+++ b/src/Faithlife.Tracing.AspNetMvc/AspNetMvcTracing.cs
@@ -20,6 +20,6 @@ namespace Faithlife.Tracing.AspNetMvc
 			}
 		}
 
-		public static ITraceProvider GetProvider(HttpContext httpContext) => AspNetTracing.GetProvider(httpContext);
+		public static ITraceProvider GetProvider(HttpContext httpContext) => AspNetTracing.GetProvider(httpContext) ?? NullTraceProvider.Instance;
 	}
 }

--- a/src/Faithlife.Tracing.AspNetWebApi/AspNetWebApiTracing.cs
+++ b/src/Faithlife.Tracing.AspNetWebApi/AspNetWebApiTracing.cs
@@ -20,6 +20,6 @@ namespace Faithlife.Tracing.AspNetWebApi
 			}
 		}
 
-		public static ITraceProvider GetProvider(HttpContext context) => AspNetTracing.GetProvider(context);
+		public static ITraceProvider GetProvider(HttpContext context) => AspNetTracing.GetProvider(context) ?? NullTraceProvider.Instance;
 	}
 }

--- a/src/Faithlife.Tracing/NullTraceProvider.cs
+++ b/src/Faithlife.Tracing/NullTraceProvider.cs
@@ -1,0 +1,18 @@
+namespace Faithlife.Tracing
+{
+	/// <summary>
+	/// An <see cref="ITraceProvider"/> that returns <c>null</c> for <c>CurrentTrace</c>.
+	/// </summary>
+	public sealed class NullTraceProvider : ITraceProvider
+	{
+		/// <summary>
+		/// An instance of <see cref="NullTraceProvider"/>.
+		/// </summary>
+		public static ITraceProvider Instance { get; } = new NullTraceProvider();
+
+		/// <summary>
+		/// The current trace, which will always be <c>null</c>.
+		/// </summary>
+		public ITrace CurrentTrace => null;
+	}
+}


### PR DESCRIPTION
Closes #2.

From the contributing guidelines:
>All new code must have complete unit tests.

What would be the best way to mock the `HttpApplication` and `HttpContext` classes for testing purposes?